### PR TITLE
fix: 🐛 Get NETWORK_CHAIN_ID from the RPC node if not provided directly

### DIFF
--- a/polymesh/deploy/docker-entrypoint.sh
+++ b/polymesh/deploy/docker-entrypoint.sh
@@ -8,13 +8,13 @@ _term() {
 trap _term SIGTERM
 
 # If NETWORK_CHAIN_ID is not set and we have an http endpoint to use, then curl the chain to fetch it (might need to retry)
-if [[ -n $NETWORK_ENDPOINT ]] && [[ -z $NETWORK_CHAIN_ID ]]
+if [[ -n $NETWORK_HTTP_ENDPOINT ]] && [[ -z $NETWORK_CHAIN_ID ]]
 then
-  export NETWORK_CHAIN_ID=$(curl --silent -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "chain_getBlockHash", "params":[0]}' $NETWORK_ENDPOINT |
+  export NETWORK_CHAIN_ID=$(curl --silent -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "chain_getBlockHash", "params":[0]}' $NETWORK_HTTP_ENDPOINT |
   grep -o '"result":"[^"]*' |
   grep -o '[^"]*$'
 )
-  echo "NETWORK_CHAIN_ID was set to ${NETWORK_CHAIN_ID} based on calling: $NETWORK_ENDPOINT. Production chains should explictly set NETWORK_CHAIN_ID instead"
+  echo "NETWORK_CHAIN_ID was set to ${NETWORK_CHAIN_ID} based on calling: $NETWORK_HTTP_ENDPOINT. Production chains should explictly set NETWORK_CHAIN_ID instead"
 fi
 
 envsubst < project.template.yaml > project.yaml # Substitute environment variables in project.template.yaml


### PR DESCRIPTION
This fixes the docker image so that it can read the CHAIN_ID from the RPC node.